### PR TITLE
Add total output

### DIFF
--- a/src/__mocks__/diffChecker.ts
+++ b/src/__mocks__/diffChecker.ts
@@ -1,4 +1,5 @@
 export const diffChecker = () => ({
-  regression: 'foo',
-  files: 'foobar'
+  regression: 'mockedRegression',
+  files: 'mockedFiles',
+  totals: { deltas: 'mockedTotals' }
 });

--- a/src/__snapshots__/coverageDiffer.test.ts.snap
+++ b/src/__snapshots__/coverageDiffer.test.ts.snap
@@ -28,12 +28,64 @@ Object {
       "total": 0,
     },
   },
+  "total": Object {
+    "branches": Object {
+      "covered": -1,
+      "pct": -50,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": -1,
+      "pct": -50,
+      "skipped": 0,
+      "total": 0,
+    },
+    "lines": Object {
+      "covered": -1,
+      "pct": -50,
+      "skipped": 0,
+      "total": 0,
+    },
+    "statements": Object {
+      "covered": -1,
+      "pct": -50,
+      "skipped": 0,
+      "total": 0,
+    },
+  },
 }
 `;
 
 exports[`coverageDiffer file coverage increased  should match snapshot 1`] = `
 Object {
   "fileA": Object {
+    "branches": Object {
+      "covered": 1,
+      "pct": 50,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 1,
+      "pct": 50,
+      "skipped": 0,
+      "total": 0,
+    },
+    "lines": Object {
+      "covered": 1,
+      "pct": 50,
+      "skipped": 0,
+      "total": 0,
+    },
+    "statements": Object {
+      "covered": 1,
+      "pct": 50,
+      "skipped": 0,
+      "total": 0,
+    },
+  },
+  "total": Object {
     "branches": Object {
       "covered": 1,
       "pct": 50,

--- a/src/__snapshots__/coverageDiffer.test.ts.snap
+++ b/src/__snapshots__/coverageDiffer.test.ts.snap
@@ -116,5 +116,31 @@ Object {
       "total": 2,
     },
   },
+  "total": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "lines": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "statements": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+  },
 }
 `;

--- a/src/__snapshots__/diffChecker.test.ts.snap
+++ b/src/__snapshots__/diffChecker.test.ts.snap
@@ -14,6 +14,15 @@ Object {
     },
   },
   "regression": true,
+  "totals": Object {
+    "decreased": false,
+    "deltas": Object {
+      "branches": 50,
+      "functions": 50,
+      "lines": 50,
+      "statements": 50,
+    },
+  },
 }
 `;
 
@@ -31,6 +40,15 @@ Object {
     },
   },
   "regression": false,
+  "totals": Object {
+    "decreased": false,
+    "deltas": Object {
+      "branches": 100,
+      "functions": 100,
+      "lines": 100,
+      "statements": 100,
+    },
+  },
 }
 `;
 
@@ -48,6 +66,15 @@ Object {
     },
   },
   "regression": false,
+  "totals": Object {
+    "decreased": false,
+    "deltas": Object {
+      "branches": 50,
+      "functions": 50,
+      "lines": 50,
+      "statements": 50,
+    },
+  },
 }
 `;
 
@@ -55,5 +82,14 @@ exports[`diffChecker skip non changed files should match snapshot 1`] = `
 Object {
   "files": Object {},
   "regression": false,
+  "totals": Object {
+    "decreased": false,
+    "deltas": Object {
+      "branches": 100,
+      "functions": 100,
+      "lines": 100,
+      "statements": 100,
+    },
+  },
 }
 `;

--- a/src/__snapshots__/diffChecker.test.ts.snap
+++ b/src/__snapshots__/diffChecker.test.ts.snap
@@ -52,6 +52,32 @@ Object {
 }
 `;
 
+exports[`diffChecker no total should match snapshot 1`] = `
+Object {
+  "files": Object {
+    "fileA": Object {
+      "decreased": false,
+      "deltas": Object {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100,
+      },
+    },
+  },
+  "regression": false,
+  "totals": Object {
+    "decreased": false,
+    "deltas": Object {
+      "branches": 0,
+      "functions": 0,
+      "lines": 0,
+      "statements": 0,
+    },
+  },
+}
+`;
+
 exports[`diffChecker only check lines should match snapshot 1`] = `
 Object {
   "files": Object {

--- a/src/__snapshots__/resultFormatter.test.ts.snap
+++ b/src/__snapshots__/resultFormatter.test.ts.snap
@@ -8,9 +8,9 @@ exports[`resultFormatter should format files results as markdown table 1`] = `
 
 Total:
 
-| Lines | Branches | Functions | Statements |
-| ----- | -------- | --------- | ---------- |
-| 100%  | 100%     | 100%      | 100%       |"
+| Lines       | Branches    | Functions   | Statements  |
+| ----------- | ----------- | ----------- | ----------- |
+| 100%(+100%) | 100%(+100%) | 100%(+100%) | 100%(+100%) |"
 `;
 
 exports[`resultFormatter should print descriptive message if coverage did't change 1`] = `
@@ -18,7 +18,7 @@ exports[`resultFormatter should print descriptive message if coverage did't chan
 
 Total:
 
-| Lines | Branches | Functions | Statements |
-| ----- | -------- | --------- | ---------- |
-| 100%  | 100%     | 100%      | 100%       |"
+| Lines       | Branches    | Functions   | Statements  |
+| ----------- | ----------- | ----------- | ----------- |
+| 100%(+100%) | 100%(+100%) | 100%(+100%) | 100%(+100%) |"
 `;

--- a/src/__snapshots__/resultFormatter.test.ts.snap
+++ b/src/__snapshots__/resultFormatter.test.ts.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`resultFormatter should format files results as markdown table 1`] = `
-"| Ok  | File  | LinesΔ(%) | BranchesΔ(%) | FunctionsΔ(%) | StatementsΔ(%) |
-| --- | ----- | --------- | ------------ | ------------- | -------------- |
-| 🔴  | file1 | 10        | -30          | 20            | -10            |
-| ✅   | file2 | 10        | 30           | 20            | 10             |
+"| Ok  | File  | LinesΔ | BranchesΔ | FunctionsΔ | StatementsΔ |
+| --- | ----- | ------ | --------- | ---------- | ----------- |
+| 🔴  | file1 | +10%   | -30%      | +20%       | -10%        |
+| ✅   | file2 | +10%   | +30%      | +20%       | +10%        |
 
 Total:
 

--- a/src/__snapshots__/resultFormatter.test.ts.snap
+++ b/src/__snapshots__/resultFormatter.test.ts.snap
@@ -4,7 +4,21 @@ exports[`resultFormatter should format files results as markdown table 1`] = `
 "| Ok  | File  | LinesΔ(%) | BranchesΔ(%) | FunctionsΔ(%) | StatementsΔ(%) |
 | --- | ----- | --------- | ------------ | ------------- | -------------- |
 | 🔴  | file1 | 10        | -30          | 20            | -10            |
-| ✅   | file2 | 10        | 30           | 20            | 10             |"
+| ✅   | file2 | 10        | 30           | 20            | 10             |
+
+Total:
+
+| Lines | Branches | Functions | Statements |
+| ----- | -------- | --------- | ---------- |
+| 100%  | 100%     | 100%      | 100%       |"
 `;
 
-exports[`resultFormatter should print descriptive message if coverage did't change 1`] = `"Coverage values did not change👌."`;
+exports[`resultFormatter should print descriptive message if coverage did't change 1`] = `
+"Coverage values did not change👌.
+
+Total:
+
+| Lines | Branches | Functions | Statements |
+| ----- | -------- | --------- | ---------- |
+| 100%  | 100%     | 100%      | 100%       |"
+`;

--- a/src/common.d.ts
+++ b/src/common.d.ts
@@ -42,3 +42,7 @@ export interface IFileResultFormat {
   };
   decreased: boolean;
 }
+
+export interface ITotalResultFormat extends IFileResultFormat {
+  totals: ICoverageSummary;
+}

--- a/src/diffChecker.test.ts
+++ b/src/diffChecker.test.ts
@@ -3,7 +3,8 @@ import {
   fileFullCovered,
   coverageDecreased,
   onlyLinesIncreased,
-  coverageNotChanged
+  coverageNotChanged,
+  noTotal
 } from './summaries.fixture';
 import { Criteria } from './common';
 
@@ -18,6 +19,11 @@ describe('diffChecker', () => {
   describe('coverage increased', () => {
     it('should match snapshot', () => {
       expect(diffChecker(fileFullCovered, checkCriteria)).toMatchSnapshot();
+    });
+  });
+  describe('no total', () => {
+    it('should match snapshot', () => {
+      expect(diffChecker(noTotal, checkCriteria)).toMatchSnapshot();
     });
   });
   describe('coverage decreased', () => {

--- a/src/diffChecker.ts
+++ b/src/diffChecker.ts
@@ -1,9 +1,9 @@
 import { objectToMap, mapToObject } from './helpers';
+import { getSummaryPercentages } from './helpers';
 import {
   IJsonSummary,
   IFilesResults,
   IFileResultFormat,
-  ICoverageSummary,
   Criteria
 } from './common';
 /**
@@ -52,10 +52,3 @@ export const diffChecker = (
     regression
   };
 };
-
-const getSummaryPercentages = (summary: ICoverageSummary) => ({
-  lines: summary.lines.pct,
-  statements: summary.statements.pct,
-  functions: summary.functions.pct,
-  branches: summary.branches.pct
-});

--- a/src/diffChecker.ts
+++ b/src/diffChecker.ts
@@ -16,7 +16,7 @@ export const diffChecker = (
   checkCriteria: Criteria[]
 ): {
   files: IFilesResults;
-  totals: IFileResultFormat | undefined;
+  totals: IFileResultFormat;
   regression: boolean;
 } => {
   let regression = false;
@@ -48,7 +48,14 @@ export const diffChecker = (
     }
   });
 
-  const totals = percentageMap.get('total');
+  let totals = percentageMap.get('total');
+
+  if (!totals) {
+    totals = {
+      deltas: { lines: 0, functions: 0, statements: 0, branches: 0 },
+      decreased: false
+    };
+  }
 
   // Exclude total from files output.
   percentageMap.delete('total');

--- a/src/diffChecker.ts
+++ b/src/diffChecker.ts
@@ -9,20 +9,21 @@ import {
 /**
  * Takes a json-summary formatted object (a diff) and checks if per-file
  *   coverage changed (increase/decrease).
- * Returns a pretty-formatted result and regression status.
+ * Returns a structured result and regression status.
  */
 export const diffChecker = (
   diff: IJsonSummary,
   checkCriteria: Criteria[]
-): { files: IFilesResults; regression: boolean } => {
+): {
+  files: IFilesResults;
+  totals: IFileResultFormat | undefined;
+  regression: boolean;
+} => {
   let regression = false;
   const diffMap = objectToMap(diff);
   const percentageMap: Map<string, IFileResultFormat> = new Map();
   const isBelowThreshold = (x: number) => x < 0;
   const nonZeroTest = (x: number) => x !== 0;
-
-  // TODO total will have custom formatting in a future release. Exclude for now.
-  diffMap.delete('total');
 
   diffMap.forEach((v, k) => {
     const percentages = getSummaryPercentages(v);
@@ -47,8 +48,14 @@ export const diffChecker = (
     }
   });
 
+  const totals = percentageMap.get('total');
+
+  // Exclude total from files output.
+  percentageMap.delete('total');
+
   return {
     files: mapToObject(percentageMap),
+    totals,
     regression
   };
 };

--- a/src/diffChecker.ts
+++ b/src/diffChecker.ts
@@ -3,6 +3,7 @@ import {
   IJsonSummary,
   IFilesResults,
   IFileResultFormat,
+  ICoverageSummary,
   Criteria
 } from './common';
 /**
@@ -24,17 +25,7 @@ export const diffChecker = (
   diffMap.delete('total');
 
   diffMap.forEach((v, k) => {
-    const { pct: lines } = v.lines;
-    const { pct: statements } = v.statements;
-    const { pct: functions } = v.functions;
-    const { pct: branches } = v.branches;
-
-    const percentages = {
-      lines,
-      statements,
-      functions,
-      branches
-    };
+    const percentages = getSummaryPercentages(v);
 
     const diffCriteria = checkCriteria.map(criteria => percentages[criteria]);
 
@@ -49,10 +40,7 @@ export const diffChecker = (
     if (diffCriteria.some(nonZeroTest)) {
       percentageMap.set(k, {
         deltas: {
-          lines,
-          statements,
-          functions,
-          branches
+          ...percentages
         },
         decreased
       });
@@ -64,3 +52,10 @@ export const diffChecker = (
     regression
   };
 };
+
+const getSummaryPercentages = (summary: ICoverageSummary) => ({
+  lines: summary.lines.pct,
+  statements: summary.statements.pct,
+  functions: summary.functions.pct,
+  branches: summary.branches.pct
+});

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,5 @@
+import { ICoverageSummary } from './common';
+
 // Typing this is so complex. Better to inline the code altogether.
 export const mapToObject = <T extends {}>(
   map: Map<string, T>
@@ -12,3 +14,10 @@ export const mapToObject = <T extends {}>(
 export const objectToMap = <T extends {}>(obj: {
   [key: string]: T;
 }): Map<string, T> => new Map(Object.entries(obj));
+
+export const getSummaryPercentages = (summary: ICoverageSummary) => ({
+  lines: summary.lines.pct,
+  statements: summary.statements.pct,
+  functions: summary.functions.pct,
+  branches: summary.branches.pct
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -37,7 +37,10 @@ describe('diff', () => {
     });
 
     it('should call the resultFormatter module', () => {
-      expect(resultFormatterSpy).toHaveBeenCalledWith('foobar');
+      expect(resultFormatterSpy).toHaveBeenCalledWith(
+        'foobar',
+        fileFullCovered.total
+      );
     });
 
     it('should return diff info', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -37,17 +37,17 @@ describe('diff', () => {
     });
 
     it('should call the resultFormatter module', () => {
-      expect(resultFormatterSpy).toHaveBeenCalledWith(
-        'foobar',
-        fileFullCovered.total
-      );
+      expect(resultFormatterSpy).toHaveBeenCalledWith('mockedFiles', {
+        totals: fileFullCovered.total,
+        deltas: 'mockedTotals'
+      });
     });
 
     it('should return diff info', () => {
       expect(diffOutput).toEqual({
         diff: 'coverageDiffer mock',
         results: 'resultFormatter mock',
-        regression: 'foo'
+        regression: 'mockedRegression'
       });
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export function diff(
 ): ICoverageDiffOutput {
   const diff = coverageDiffer(base, head);
   const { regression, files } = diffChecker(diff, options.checkCriteria);
-  const results = resultFormatter(files);
+  const results = resultFormatter(files, head.total);
 
   return {
     diff,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 import { coverageDiffer } from './coverageDiffer';
 import { diffChecker } from './diffChecker';
 import { resultFormatter } from './resultFormatter';
-import { IJsonSummary, ICoverageDiffOutput, IConfigOptions } from './common';
+import {
+  IJsonSummary,
+  ICoverageDiffOutput,
+  IConfigOptions,
+  ITotalResultFormat
+} from './common';
 
 export const defaultOptions: IConfigOptions = {
   checkCriteria: ['lines', 'branches', 'functions', 'statements']
@@ -17,8 +22,15 @@ export function diff(
   options: IConfigOptions = defaultOptions
 ): ICoverageDiffOutput {
   const diff = coverageDiffer(base, head);
-  const { regression, files } = diffChecker(diff, options.checkCriteria);
-  const results = resultFormatter(files, head.total);
+  const { regression, files, totals } = diffChecker(
+    diff,
+    options.checkCriteria
+  );
+  const totalResults: ITotalResultFormat = {
+    totals: head.total,
+    ...totals
+  };
+  const results = resultFormatter(files, totalResults);
 
   return {
     diff,

--- a/src/resultFormatter.test.ts
+++ b/src/resultFormatter.test.ts
@@ -1,4 +1,4 @@
-import { IFilesResults } from './common';
+import { IFilesResults, ITotalResultFormat } from './common';
 import { resultFormatter } from './resultFormatter';
 import { fileFullCovered } from './summaries.fixture';
 
@@ -23,14 +23,23 @@ const filesResults: IFilesResults = {
   }
 };
 
+const totalResults: ITotalResultFormat = {
+  totals: fileFullCovered.total,
+  deltas: {
+    lines: 100,
+    functions: 100,
+    branches: 100,
+    statements: 100
+  },
+  decreased: false
+};
+
 describe('resultFormatter', () => {
   it('should format files results as markdown table', () => {
-    expect(
-      resultFormatter(filesResults, fileFullCovered.total)
-    ).toMatchSnapshot();
+    expect(resultFormatter(filesResults, totalResults)).toMatchSnapshot();
   });
 
   it("should print descriptive message if coverage did't change", () => {
-    expect(resultFormatter({}, fileFullCovered.total)).toMatchSnapshot();
+    expect(resultFormatter({}, totalResults)).toMatchSnapshot();
   });
 });

--- a/src/resultFormatter.test.ts
+++ b/src/resultFormatter.test.ts
@@ -1,5 +1,6 @@
 import { IFilesResults } from './common';
 import { resultFormatter } from './resultFormatter';
+import { fileFullCovered } from './summaries.fixture';
 
 const filesResults: IFilesResults = {
   file1: {
@@ -24,10 +25,12 @@ const filesResults: IFilesResults = {
 
 describe('resultFormatter', () => {
   it('should format files results as markdown table', () => {
-    expect(resultFormatter(filesResults)).toMatchSnapshot();
+    expect(
+      resultFormatter(filesResults, fileFullCovered.total)
+    ).toMatchSnapshot();
   });
 
   it("should print descriptive message if coverage did't change", () => {
-    expect(resultFormatter({})).toMatchSnapshot();
+    expect(resultFormatter({}, fileFullCovered.total)).toMatchSnapshot();
   });
 });

--- a/src/resultFormatter.ts
+++ b/src/resultFormatter.ts
@@ -1,23 +1,34 @@
 import markdownTable from 'markdown-table';
 import { getSummaryPercentages } from './helpers';
-import { IFilesResults, ICoverageSummary } from './common';
+import { IFilesResults, ITotalResultFormat } from './common';
 
 export const resultFormatter = (
   files: IFilesResults,
-  total: ICoverageSummary
+  total: ITotalResultFormat
 ): string => {
   const formattedFiles = formatFilesResults(files);
   const formattedTotal = formatTotal(total);
   return `${formattedFiles}${formattedTotal}`;
 };
 
-const formatTotal = (total: ICoverageSummary): string => {
+const formatTotal = (total: ITotalResultFormat): string => {
   const table: Array<(string | number)[]> = [];
   const { lines, branches, functions, statements } = getSummaryPercentages(
-    total
+    total.totals
   );
+
+  const lDelta = formatDelta(total.deltas.lines);
+  const bDelta = formatDelta(total.deltas.branches);
+  const fDelta = formatDelta(total.deltas.functions);
+  const sDelta = formatDelta(total.deltas.statements);
+
   table.push(['Lines', 'Branches', 'Functions', 'Statements']);
-  table.push([`${lines}%`, `${branches}%`, `${functions}%`, `${statements}%`]);
+  table.push([
+    `${lines}%(${lDelta})`,
+    `${branches}%(${bDelta})`,
+    `${functions}%(${fDelta})`,
+    `${statements}%(${sDelta})`
+  ]);
 
   return '\n\nTotal:\n\n' + markdownTable(table);
 };

--- a/src/resultFormatter.ts
+++ b/src/resultFormatter.ts
@@ -28,10 +28,10 @@ const formatFilesResults = (files: IFilesResults): string => {
   const header = [
     'Ok',
     'File',
-    'LinesΔ(%)',
-    'BranchesΔ(%)',
-    'FunctionsΔ(%)',
-    'StatementsΔ(%)'
+    'LinesΔ',
+    'BranchesΔ',
+    'FunctionsΔ',
+    'StatementsΔ'
   ];
   table.push(header);
 
@@ -40,10 +40,10 @@ const formatFilesResults = (files: IFilesResults): string => {
     const row = [
       decreased ? '🔴' : '✅',
       file,
-      deltas.lines,
-      deltas.branches,
-      deltas.functions,
-      deltas.statements
+      formatDelta(deltas.lines),
+      formatDelta(deltas.branches),
+      formatDelta(deltas.functions),
+      formatDelta(deltas.statements)
     ];
 
     table.push(row);
@@ -51,4 +51,8 @@ const formatFilesResults = (files: IFilesResults): string => {
   });
 
   return noChange ? 'Coverage values did not change👌.' : markdownTable(table);
+};
+
+const formatDelta = (num: number): string => {
+  return num >= 0 ? `+${num}%` : `${num}%`;
 };

--- a/src/resultFormatter.ts
+++ b/src/resultFormatter.ts
@@ -1,7 +1,28 @@
 import markdownTable from 'markdown-table';
-import { IFilesResults } from './common';
+import { getSummaryPercentages } from './helpers';
+import { IFilesResults, ICoverageSummary } from './common';
 
-export const resultFormatter = (files: IFilesResults): string => {
+export const resultFormatter = (
+  files: IFilesResults,
+  total: ICoverageSummary
+): string => {
+  const formattedFiles = formatFilesResults(files);
+  const formattedTotal = formatTotal(total);
+  return `${formattedFiles}${formattedTotal}`;
+};
+
+const formatTotal = (total: ICoverageSummary): string => {
+  const table: Array<(string | number)[]> = [];
+  const { lines, branches, functions, statements } = getSummaryPercentages(
+    total
+  );
+  table.push(['Lines', 'Branches', 'Functions', 'Statements']);
+  table.push([`${lines}%`, `${branches}%`, `${functions}%`, `${statements}%`]);
+
+  return '\n\nTotal:\n\n' + markdownTable(table);
+};
+
+const formatFilesResults = (files: IFilesResults): string => {
   let noChange = true;
   const table: Array<(string | number)[]> = [];
   const header = [

--- a/src/summaries.fixture.ts
+++ b/src/summaries.fixture.ts
@@ -251,6 +251,7 @@ export const coverageDecreased: IJsonSummary = {
 };
 
 export const onlyLinesIncreased: IJsonSummary = {
+  ...coverageDecreased,
   fileA: {
     ...coverageDecreased.fileA,
     lines: {

--- a/src/summaries.fixture.ts
+++ b/src/summaries.fixture.ts
@@ -250,6 +250,35 @@ export const coverageDecreased: IJsonSummary = {
   }
 };
 
+export const noTotal: IJsonSummary = {
+  fileA: {
+    lines: {
+      total: 2,
+      covered: 2,
+      skipped: 0,
+      pct: 100
+    },
+    statements: {
+      total: 2,
+      covered: 2,
+      skipped: 0,
+      pct: 100
+    },
+    functions: {
+      total: 2,
+      covered: 2,
+      skipped: 0,
+      pct: 100
+    },
+    branches: {
+      total: 2,
+      covered: 2,
+      skipped: 0,
+      pct: 100
+    }
+  }
+};
+
 export const onlyLinesIncreased: IJsonSummary = {
   ...coverageDecreased,
   fileA: {

--- a/src/summaries.fixture.ts
+++ b/src/summaries.fixture.ts
@@ -1,133 +1,5 @@
 import { IJsonSummary } from './common';
 
-export const fileNotCovered: IJsonSummary = {
-  fileA: {
-    lines: {
-      total: 2,
-      covered: 0,
-      skipped: 0,
-      pct: 0
-    },
-    statements: {
-      total: 2,
-      covered: 0,
-      skipped: 0,
-      pct: 0
-    },
-    functions: {
-      total: 2,
-      covered: 0,
-      skipped: 0,
-      pct: 0
-    },
-    branches: {
-      total: 2,
-      covered: 0,
-      skipped: 0,
-      pct: 0
-    }
-  }
-};
-
-export const fileHalfCovered: IJsonSummary = {
-  fileA: {
-    lines: {
-      total: 2,
-      covered: 1,
-      skipped: 0,
-      pct: 50
-    },
-    statements: {
-      total: 2,
-      covered: 1,
-      skipped: 0,
-      pct: 50
-    },
-    functions: {
-      total: 2,
-      covered: 1,
-      skipped: 0,
-      pct: 50
-    },
-    branches: {
-      total: 2,
-      covered: 1,
-      skipped: 0,
-      pct: 50
-    }
-  }
-};
-
-export const coverageNotChanged: IJsonSummary = {
-  fileA: {
-    lines: {
-      total: 2,
-      covered: 1,
-      skipped: 0,
-      pct: 0
-    },
-    statements: {
-      total: 2,
-      covered: 1,
-      skipped: 0,
-      pct: 0
-    },
-    functions: {
-      total: 2,
-      covered: 1,
-      skipped: 0,
-      pct: 0
-    },
-    branches: {
-      total: 2,
-      covered: 1,
-      skipped: 0,
-      pct: 0
-    }
-  }
-};
-
-export const coverageDecreased: IJsonSummary = {
-  fileA: {
-    lines: {
-      total: 0,
-      covered: -1,
-      skipped: 0,
-      pct: -50
-    },
-    statements: {
-      total: 0,
-      covered: -1,
-      skipped: 0,
-      pct: -50
-    },
-    functions: {
-      total: 0,
-      covered: -1,
-      skipped: 0,
-      pct: -50
-    },
-    branches: {
-      total: 0,
-      covered: -1,
-      skipped: 0,
-      pct: -50
-    }
-  }
-};
-
-export const onlyLinesIncreased: IJsonSummary = {
-  fileA: {
-    ...coverageDecreased.fileA,
-    lines: {
-      total: 0,
-      covered: 1,
-      skipped: 0,
-      pct: 50
-    }
-  }
-};
-
 export const fileFullCovered: IJsonSummary = {
   total: {
     lines: {
@@ -179,6 +51,213 @@ export const fileFullCovered: IJsonSummary = {
       covered: 2,
       skipped: 0,
       pct: 100
+    }
+  }
+};
+
+export const fileNotCovered: IJsonSummary = {
+  total: {
+    lines: {
+      total: 2,
+      covered: 0,
+      skipped: 0,
+      pct: 0
+    },
+    statements: {
+      total: 2,
+      covered: 0,
+      skipped: 0,
+      pct: 0
+    },
+    functions: {
+      total: 2,
+      covered: 0,
+      skipped: 0,
+      pct: 0
+    },
+    branches: {
+      total: 2,
+      covered: 0,
+      skipped: 0,
+      pct: 0
+    }
+  },
+  fileA: {
+    lines: {
+      total: 2,
+      covered: 0,
+      skipped: 0,
+      pct: 0
+    },
+    statements: {
+      total: 2,
+      covered: 0,
+      skipped: 0,
+      pct: 0
+    },
+    functions: {
+      total: 2,
+      covered: 0,
+      skipped: 0,
+      pct: 0
+    },
+    branches: {
+      total: 2,
+      covered: 0,
+      skipped: 0,
+      pct: 0
+    }
+  }
+};
+
+export const fileHalfCovered: IJsonSummary = {
+  total: {
+    lines: {
+      total: 2,
+      covered: 1,
+      skipped: 0,
+      pct: 50
+    },
+    statements: {
+      total: 2,
+      covered: 1,
+      skipped: 0,
+      pct: 50
+    },
+    functions: {
+      total: 2,
+      covered: 1,
+      skipped: 0,
+      pct: 50
+    },
+    branches: {
+      total: 2,
+      covered: 1,
+      skipped: 0,
+      pct: 50
+    }
+  },
+  fileA: {
+    lines: {
+      total: 2,
+      covered: 1,
+      skipped: 0,
+      pct: 50
+    },
+    statements: {
+      total: 2,
+      covered: 1,
+      skipped: 0,
+      pct: 50
+    },
+    functions: {
+      total: 2,
+      covered: 1,
+      skipped: 0,
+      pct: 50
+    },
+    branches: {
+      total: 2,
+      covered: 1,
+      skipped: 0,
+      pct: 50
+    }
+  }
+};
+
+export const coverageNotChanged: IJsonSummary = {
+  ...fileFullCovered,
+  fileA: {
+    lines: {
+      total: 2,
+      covered: 1,
+      skipped: 0,
+      pct: 0
+    },
+    statements: {
+      total: 2,
+      covered: 1,
+      skipped: 0,
+      pct: 0
+    },
+    functions: {
+      total: 2,
+      covered: 1,
+      skipped: 0,
+      pct: 0
+    },
+    branches: {
+      total: 2,
+      covered: 1,
+      skipped: 0,
+      pct: 0
+    }
+  }
+};
+
+export const coverageDecreased: IJsonSummary = {
+  total: {
+    lines: {
+      total: 0,
+      covered: 1,
+      skipped: 0,
+      pct: 50
+    },
+    statements: {
+      total: 0,
+      covered: 1,
+      skipped: 0,
+      pct: 50
+    },
+    functions: {
+      total: 0,
+      covered: 1,
+      skipped: 0,
+      pct: 50
+    },
+    branches: {
+      total: 0,
+      covered: 1,
+      skipped: 0,
+      pct: 50
+    }
+  },
+  fileA: {
+    lines: {
+      total: 0,
+      covered: -1,
+      skipped: 0,
+      pct: -50
+    },
+    statements: {
+      total: 0,
+      covered: -1,
+      skipped: 0,
+      pct: -50
+    },
+    functions: {
+      total: 0,
+      covered: -1,
+      skipped: 0,
+      pct: -50
+    },
+    branches: {
+      total: 0,
+      covered: -1,
+      skipped: 0,
+      pct: -50
+    }
+  }
+};
+
+export const onlyLinesIncreased: IJsonSummary = {
+  fileA: {
+    ...coverageDecreased.fileA,
+    lines: {
+      total: 0,
+      covered: 1,
+      skipped: 0,
+      pct: 50
     }
   }
 };

--- a/src/summaries.fixture.ts
+++ b/src/summaries.fixture.ts
@@ -129,6 +129,32 @@ export const onlyLinesIncreased: IJsonSummary = {
 };
 
 export const fileFullCovered: IJsonSummary = {
+  total: {
+    lines: {
+      total: 2,
+      covered: 2,
+      skipped: 0,
+      pct: 100
+    },
+    statements: {
+      total: 2,
+      covered: 2,
+      skipped: 0,
+      pct: 100
+    },
+    functions: {
+      total: 2,
+      covered: 2,
+      skipped: 0,
+      pct: 100
+    },
+    branches: {
+      total: 2,
+      covered: 2,
+      skipped: 0,
+      pct: 100
+    }
+  },
   fileA: {
     lines: {
       total: 2,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
    "extends": "./tsconfig.json",
-   "exclude": ["**/*.test.*", "**/*.fixture.*"]
+   "exclude": ["**/*.test.*", "**/*.fixture.*", "**/__mocks__/"]
 }


### PR DESCRIPTION
- Adds new total coverage table report. Displays total and total delta.

Total:

| Lines       | Branches    | Functions   | Statements  |
| ----------- | ----------- | ----------- | ----------- |
| 100%(+100%) | 100%(+100%) | 100%(+100%) | 100%(+100%) |

- Adds `%` and `+` signs to files coverage values