### PR TITLE
Fix typo in option name

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -30,7 +30,11 @@ export interface IConfigOptions {
   /* Fail coverage check if per-file coverage is lower */
   coverageThreshold?: number;
   /* Fail coverage check if per-file coverage decrease is lower */
+  /**
+   * @deprecated use coverageDecreaseThreshold instead
+   */
   coverageDecreaseTreshold?: number;
+  coverageDecreaseThreshold?: number;
 }
 
 export interface IDiffCheckResults {

--- a/src/diffChecker.test.ts
+++ b/src/diffChecker.test.ts
@@ -22,7 +22,7 @@ describe('diffChecker', () => {
   describe('coverage decreased over total treshold', () => {
     let result: IDiffCheckResults;
     beforeEach(() => {
-      // Set coverageDecreaseTreshold to 100% so we only test coverageTreshold.
+      // Set coverageDecreaseThreshold to 100% so we only test coverageTreshold.
       result = diffChecker(
         fileFullCovered,
         fileHalfCovered,

--- a/src/diffChecker.ts
+++ b/src/diffChecker.ts
@@ -19,7 +19,7 @@ export const diffChecker = (
   head: IJsonSummary,
   checkCriteria = defaultOptions.checkCriteria!,
   coverageThreshold = defaultOptions.coverageThreshold!,
-  coverageDecreaseTreshold = defaultOptions.coverageDecreaseTreshold!
+  coverageDecreaseThreshold = defaultOptions.coverageDecreaseThreshold!
 ): IDiffCheckResults => {
   let regression = false;
   const diff = coverageDiffer(base, head);
@@ -27,7 +27,7 @@ export const diffChecker = (
   const percentageMap: Map<string, IFileResultFormat> = new Map();
   const nonZeroTest = (x: number) => x !== 0;
   const coverageDecreased = (x: number) =>
-    x < 0 ? Math.abs(x) >= coverageDecreaseTreshold : false;
+    x < 0 ? Math.abs(x) >= coverageDecreaseThreshold : false;
   const isBelowTreshold = (x: number) => x < coverageThreshold;
 
   diffMap.forEach((v, k) => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,11 +10,6 @@ import { fileNotCovered, fileFullCovered } from './summaries.fixture';
 
 const diffCheckerSpy = jest.spyOn(diffChecker, 'diffChecker');
 const resultFormatterSpy = jest.spyOn(resultFormatter, 'resultFormatter');
-const mockedOptions: IConfigOptions = {
-  checkCriteria: ['lines'],
-  coverageThreshold: 100,
-  coverageDecreaseTreshold: 0
-};
 
 describe('diff', () => {
   describe('default options', () => {
@@ -29,7 +24,7 @@ describe('diff', () => {
         fileFullCovered,
         coverageDiff.defaultOptions.checkCriteria,
         coverageDiff.defaultOptions.coverageThreshold,
-        coverageDiff.defaultOptions.coverageDecreaseTreshold
+        coverageDiff.defaultOptions.coverageDecreaseThreshold
       );
     });
 
@@ -49,10 +44,33 @@ describe('diff', () => {
     });
   });
   describe('custom Options', () => {
-    beforeEach(() => {
-      coverageDiff.diff(fileNotCovered, fileFullCovered, mockedOptions);
-    });
     it('should call the diffChecker module', () => {
+      const mockedOptions: IConfigOptions = {
+        checkCriteria: ['lines'],
+        coverageThreshold: 100,
+        coverageDecreaseThreshold: 0
+      };
+
+      coverageDiff.diff(fileNotCovered, fileFullCovered, mockedOptions);
+
+      expect(diffCheckerSpy).toHaveBeenCalledWith(
+        fileNotCovered,
+        fileFullCovered,
+        mockedOptions.checkCriteria,
+        mockedOptions.coverageThreshold,
+        mockedOptions.coverageDecreaseThreshold
+      );
+    });
+
+    it('should call the diffChecker module with deprecated option', () => {
+      const mockedOptions: IConfigOptions = {
+        checkCriteria: ['lines'],
+        coverageThreshold: 100,
+        coverageDecreaseTreshold: 0
+      };
+
+      coverageDiff.diff(fileNotCovered, fileFullCovered, mockedOptions);
+
       expect(diffCheckerSpy).toHaveBeenCalledWith(
         fileNotCovered,
         fileFullCovered,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
 export const defaultOptions: IConfigOptions = {
   checkCriteria: ['lines', 'branches', 'functions', 'statements'],
   coverageThreshold: 100,
-  coverageDecreaseTreshold: 0
+  coverageDecreaseThreshold: 0
 };
 
 /**
@@ -25,7 +25,8 @@ export function diff(
   const {
     checkCriteria,
     coverageThreshold,
-    coverageDecreaseTreshold
+    coverageDecreaseThreshold,
+    coverageDecreaseTreshold: deprecatedCoverageDecreaseThreshold
   } = options;
 
   const { regression, files, totals, diff } = diffChecker(
@@ -33,7 +34,9 @@ export function diff(
     head,
     checkCriteria,
     coverageThreshold,
-    coverageDecreaseTreshold
+    coverageDecreaseThreshold !== undefined
+      ? coverageDecreaseThreshold
+      : deprecatedCoverageDecreaseThreshold
   );
 
   const totalResults: ITotalResultFormat = {


### PR DESCRIPTION
There was a typo in the name `coverageDecreaseThreshold`

```diff
-coverageDecreaseTreshold
+coverageDecreaseThreshold
```

Fixed that, but also left the old option around as `@deprecated`, for backwards copatibility. So a minor release is enough.