### PR TITLE
Print total percentages even if they haven't changed

### DIFF
--- a/src/__snapshots__/diffChecker.test.ts.snap
+++ b/src/__snapshots__/diffChecker.test.ts.snap
@@ -359,10 +359,10 @@ Object {
       "statements": 0,
     },
     "pcts": Object {
-      "branches": 0,
-      "functions": 0,
-      "lines": 0,
-      "statements": 0,
+      "branches": 50,
+      "functions": 50,
+      "lines": 50,
+      "statements": 50,
     },
   },
 }
@@ -435,10 +435,10 @@ Object {
       "statements": 0,
     },
     "pcts": Object {
-      "branches": 0,
-      "functions": 0,
-      "lines": 0,
-      "statements": 0,
+      "branches": 100,
+      "functions": 100,
+      "lines": 100,
+      "statements": 100,
     },
   },
 }

--- a/src/diffChecker.test.ts
+++ b/src/diffChecker.test.ts
@@ -43,6 +43,20 @@ describe('diffChecker', () => {
     it('should match snapshot', () => {
       expect(diffChecker(fileFullCovered, fileFullCovered)).toMatchSnapshot();
     });
+
+    it('should return total percentages', () => {
+      expect(
+        diffChecker(fileFullCovered, fileFullCovered, undefined, 0).totals
+      ).toMatchObject({
+        deltas: { lines: 0, functions: 0, statements: 0, branches: 0 },
+        pcts: {
+          lines: 100,
+          functions: 100,
+          statements: 100,
+          branches: 100
+        }
+      });
+    });
   });
   describe('only check lines', () => {
     it('should match snapshot', () => {

--- a/src/diffChecker.ts
+++ b/src/diffChecker.ts
@@ -67,7 +67,12 @@ export const diffChecker = (
   if (!totals) {
     totals = {
       deltas: { lines: 0, functions: 0, statements: 0, branches: 0 },
-      pcts: { lines: 0, functions: 0, statements: 0, branches: 0 },
+      pcts: {
+        lines: head.total.lines.pct,
+        functions: head.total.functions.pct,
+        statements: head.total.statements.pct,
+        branches: head.total.branches.pct
+      },
       decreased: false
     };
   }


### PR DESCRIPTION
When there is code coverage, but no change in totals the total percentages are printed as 0. 
![image](https://user-images.githubusercontent.com/7891759/157767428-25216332-3617-40d0-83b1-7db160bbda7b.png)

Introduced by the PR that added the current values to the report - [here](https://github.com/flaviusone/coverage-diff/pull/8/files#diff-a0a8decef07f43a4b9e540f3c9d2012816af210a679ce332057d7ebeb39b3a6bR70)

The total percentages should still be printed though. This PR fixes that:
![image](https://user-images.githubusercontent.com/7891759/157767462-7dee8020-e863-40bf-8d36-a49da08eeea7.png)


Unit test added and snapshots updated to reflect the change.