### PR TITLE
split regression to regression and belowThreshold

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -21,6 +21,7 @@ export interface CoverageDiffOutput {
   diff: JsonSummary;
   results: string;
   regression: boolean;
+  belowThreshold: boolean;
 }
 
 export type Criteria = 'lines' | 'branches' | 'functions' | 'statements';
@@ -38,6 +39,7 @@ export interface DiffCheckResults {
   totals: FileResultFormat;
   diff: JsonSummary;
   regression: boolean;
+  belowThreshold: boolean;
 }
 
 export interface FilesResults {
@@ -48,6 +50,7 @@ export interface FileResultFormat {
   deltas: FileResultFields;
   pcts: FileResultFields;
   decreased: boolean;
+  belowThreshold: boolean;
 }
 
 export interface FileResultFields {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export function diff(
   const { checkCriteria, coverageThreshold, coverageDecreaseThreshold } =
     options;
 
-  const { regression, files, totals, diff } = diffChecker(
+  const { regression, files, totals, diff, belowThreshold } = diffChecker(
     base,
     head,
     checkCriteria,
@@ -33,7 +33,8 @@ export function diff(
   return {
     diff,
     results,
-    regression
+    regression,
+    belowThreshold
   };
 }
 export { JsonSummary, CoverageDiffOutput, ConfigOptions };

--- a/src/resultFormatter.test.ts
+++ b/src/resultFormatter.test.ts
@@ -15,7 +15,8 @@ const filesResults: FilesResults = {
       functions: 3,
       branches: 14
     },
-    decreased: true
+    decreased: true,
+    belowThreshold: false
   },
   file2: {
     deltas: {
@@ -30,7 +31,8 @@ const filesResults: FilesResults = {
       functions: 2,
       branches: 8
     },
-    decreased: false
+    decreased: false,
+    belowThreshold: false
   }
 };
 
@@ -47,7 +49,8 @@ const totalResults: FileResultFormat = {
     functions: 100,
     branches: 100
   },
-  decreased: false
+  decreased: false,
+  belowThreshold: false
 };
 
 describe('resultFormatter', () => {


### PR DESCRIPTION
currently regression means two things, did the coverage decrease for any file and is it below the threshold. 

I ran into this issue where coverage increased, but `regression` was still true. Here's a snapshot of the breakpoint where It sets `regression = true`
![image](https://user-images.githubusercontent.com/7891759/158633618-76783f44-decf-4045-b980-1d4f92318a9e.png)

This isn't very intuitive to me. In my opinion, `regression` should mean that there is less coverage than before.

I can work around this by ignoring the coverageThreshold by passing in `coverageThreshold: 0`, or we could default `coverageThreshold` to `0` instead of `100` but it seems like this change to split them would be more clear.

With this change I could also print two messages to the PR:
1. `There was a regression please investigate it` 
2. `Some files don't meet the coverage threshold of x%`