### PR TITLE
Add newFileCoverageThreshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   - Formatted as markdown table
 - Fail if coverage decreases on a file (check on percentage) for any of the lines/func/statements/branches. Can
    be configured to only check some criteria.
+- Separate threshold for new files `newFileCoverageThreshold`, defaults to `coverageThreshold` if not passed
 - Written in Typescript.
 
 ## Usage

--- a/src/__snapshots__/coverageDiffer.test.ts.snap
+++ b/src/__snapshots__/coverageDiffer.test.ts.snap
@@ -15,6 +15,7 @@ Object {
       "skipped": 0,
       "total": 0,
     },
+    "isNewFile": false,
     "lines": Object {
       "covered": -1,
       "pct": -50,
@@ -41,6 +42,7 @@ Object {
       "skipped": 0,
       "total": 0,
     },
+    "isNewFile": false,
     "lines": Object {
       "covered": -1,
       "pct": -50,
@@ -72,6 +74,7 @@ Object {
       "skipped": 0,
       "total": 0,
     },
+    "isNewFile": false,
     "lines": Object {
       "covered": 1,
       "pct": 50,
@@ -98,6 +101,7 @@ Object {
       "skipped": 0,
       "total": 0,
     },
+    "isNewFile": false,
     "lines": Object {
       "covered": 1,
       "pct": 50,
@@ -129,6 +133,7 @@ Object {
       "skipped": 0,
       "total": 0,
     },
+    "isNewFile": false,
     "lines": Object {
       "covered": 0,
       "pct": 0,
@@ -155,6 +160,7 @@ Object {
       "skipped": 0,
       "total": 2,
     },
+    "isNewFile": true,
     "lines": Object {
       "covered": 2,
       "pct": 100,
@@ -181,6 +187,7 @@ Object {
       "skipped": 0,
       "total": 0,
     },
+    "isNewFile": false,
     "lines": Object {
       "covered": 0,
       "pct": 0,

--- a/src/__snapshots__/resultFormatter.test.ts.snap
+++ b/src/__snapshots__/resultFormatter.test.ts.snap
@@ -1,10 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`resultFormatter should format files results as markdown table 1`] = `
-"| Ok | File  | Lines         | Branches      | Functions    | Statements    |
-| -- | ----- | ------------- | ------------- | ------------ | ------------- |
-| 🔴 | file1 | 80%<br>(+10%) | 14%<br>(-30%) | 3%<br>(+20%) | 20%<br>(-10%) |
-| ✅  | file2 | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+"| Ok | File (✨=New File) | Lines         | Branches      | Functions    | Statements    |
+| -- | ----------------- | ------------- | ------------- | ------------ | ------------- |
+| 🔴 | file1             | 80%<br>(+10%) | 14%<br>(-30%) | 3%<br>(+20%) | 20%<br>(-10%) |
+| ✅  | file2             | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| 🔴 | file3             | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
+| ✅  | ✨ file4           | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
 
 Total:
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -4,6 +4,7 @@ export interface CoverageSummary {
   statements: CoverageInfo;
   functions: CoverageInfo;
   branches: CoverageInfo;
+  isNewFile: boolean;
 }
 
 export interface CoverageInfo {
@@ -32,6 +33,8 @@ export interface ConfigOptions {
   coverageThreshold?: number;
   /* Fail coverage check if per-file coverage decrease is lower */
   coverageDecreaseThreshold?: number;
+  /* Fail coverage check if per-file coverage is lower than this for new files only */
+  newFileCoverageThreshold?: number;
 }
 
 export interface DiffCheckResults {
@@ -51,6 +54,7 @@ export interface FileResultFormat {
   pcts: FileResultFields;
   decreased: boolean;
   belowThreshold: boolean;
+  isNewFile: boolean;
 }
 
 export interface FileResultFields {

--- a/src/coverageDiffer.ts
+++ b/src/coverageDiffer.ts
@@ -22,7 +22,7 @@ export const coverageDiffer = (
       diffMap.set(k, diffSummary(v, fileSummary));
     } else {
       // New file.
-      diffMap.set(k, {...v, isNewFile: true});
+      diffMap.set(k, { ...v, isNewFile: true });
     }
   });
 

--- a/src/coverageDiffer.ts
+++ b/src/coverageDiffer.ts
@@ -11,7 +11,7 @@ export const coverageDiffer = (
 ): JsonSummary => {
   const baseMap = objectToMap(base);
   const headMap = objectToMap(head);
-  const diffMap = new Map();
+  const diffMap = new Map<string, CoverageSummary>();
 
   // Compare head against base for changed/added files.
   headMap.forEach((v, k) => {
@@ -22,7 +22,7 @@ export const coverageDiffer = (
       diffMap.set(k, diffSummary(v, fileSummary));
     } else {
       // New file.
-      diffMap.set(k, v);
+      diffMap.set(k, {...v, isNewFile: true});
     }
   });
 
@@ -40,7 +40,8 @@ const diffSummary = (
     lines: diffInfo(summaryA.lines, summaryB.lines),
     statements: diffInfo(summaryA.statements, summaryB.statements),
     functions: diffInfo(summaryA.functions, summaryB.functions),
-    branches: diffInfo(summaryA.branches, summaryB.branches)
+    branches: diffInfo(summaryA.branches, summaryB.branches),
+    isNewFile: false
   };
 };
 

--- a/src/diffChecker.test.ts
+++ b/src/diffChecker.test.ts
@@ -251,7 +251,7 @@ describe('diffChecker', () => {
       expect(result.regression).toBe(false);
     });
 
-    it.only('should be below threshold', () => {
+    it('should be below threshold', () => {
       // Total is now 75% but file threshold is 60% so it should be belowThreshold
       expect(result.belowThreshold).toBe(true);
     });

--- a/src/diffChecker.test.ts
+++ b/src/diffChecker.test.ts
@@ -259,7 +259,7 @@ describe('diffChecker', () => {
     it('outputs correct total percentages', () => {
       expectToMatchObject(result.totals, {
         belowThreshold: false, // Threshold is 60, total is 75, total is not below, but file is
-        decreased: false, 
+        decreased: false,
         pcts: {
           branches: 75,
           functions: 75,
@@ -296,7 +296,7 @@ describe('diffChecker', () => {
     it('outputs correct total percentages', () => {
       expectToMatchObject(result.totals, {
         belowThreshold: false, // Threshold is 40, total is 50
-        decreased: false, 
+        decreased: false,
         pcts: {
           branches: 50,
           functions: 50,

--- a/src/diffChecker.test.ts
+++ b/src/diffChecker.test.ts
@@ -215,7 +215,7 @@ describe('diffChecker', () => {
     });
 
     it('should be below threshold', () => {
-      // Total is now 50% but file threshold is 40%, and new file threshold is 40, so it should be below the threshold
+      // Total is now 50% but file threshold is 40%, and new file threshold is 40, new file is below threshold, global is above threshold
       expect(result.belowThreshold).toBe(true);
     });
 
@@ -252,7 +252,7 @@ describe('diffChecker', () => {
     });
 
     it('should be below threshold', () => {
-      // Total is now 75% but file threshold is 60% so it should be belowThreshold
+      // Total is now 75% but file threshold is 60%, new file is below threshold, global is above threshold
       expect(result.belowThreshold).toBe(true);
     });
 
@@ -289,8 +289,8 @@ describe('diffChecker', () => {
     });
 
     it('should not be below threshold', () => {
-      // Total is now 50% but file threshold is 40%, and new file threshold is 45, so it should be above the threshold
-      expect(result.belowThreshold).toBe(false);
+      // Total is now 50% but file threshold is 40%, and new file threshold is 45, new file is below threshold, global is above threshold
+      expect(result.belowThreshold).toBe(true);
     });
 
     it('outputs correct total percentages', () => {

--- a/src/diffChecker.test.ts
+++ b/src/diffChecker.test.ts
@@ -4,7 +4,9 @@ import {
   onlyLinesIncreased,
   fileNotCovered,
   fileHalfCovered,
-  fileFullCoveredfileHalfCovered
+  fileFullCoveredfileHalfCovered,
+  newFileNotCovered,
+  newFileHalfCovered
 } from './summaries.fixture';
 import { DiffCheckResults } from './common';
 import { expectToMatchObject } from './testHelpers';
@@ -134,12 +136,12 @@ describe('diffChecker', () => {
     });
 
     it('should not regress', () => {
-      // Total is now 50% but overall threshold is 40% so it still passes.
+      // Total is now 50% but the first file didn't change so no regression
       expect(result.regression).toBe(false);
     });
 
     it('should be below threshold', () => {
-      // Total is now 50% but overall threshold is 40% so it still passes.
+      // Total is now 50% but file threshold is 60% so it should be belowThreshold.
       expect(result.belowThreshold).toBe(true);
     });
 
@@ -147,6 +149,154 @@ describe('diffChecker', () => {
       expectToMatchObject(result.totals, {
         belowThreshold: true,
         decreased: false, // Threshold is 60
+        pcts: {
+          branches: 50,
+          functions: 50,
+          lines: 50,
+          statements: 50
+        }
+      });
+    });
+  });
+
+  describe('new file with no coverage below threshold', () => {
+    beforeEach(() => {
+      // Set coverageDecreaseThreshold to 100% so we only test coverageThreshold.
+      result = diffChecker(
+        fileFullCovered,
+        newFileNotCovered,
+        undefined,
+        60,
+        100,
+        60
+      );
+    });
+
+    it('should not regress', () => {
+      // Total is now 50% but the first file didn't change so no regression
+      expect(result.regression).toBe(false);
+    });
+
+    it('should be below threshold', () => {
+      // Total is now 50% but file threshold is 60% so it should be belowThreshold.
+      expect(result.belowThreshold).toBe(true);
+    });
+
+    it('outputs correct total percentages', () => {
+      expectToMatchObject(result.totals, {
+        belowThreshold: true,
+        decreased: false, // Threshold is 60
+        pcts: {
+          branches: 50,
+          functions: 50,
+          lines: 50,
+          statements: 50
+        }
+      });
+    });
+  });
+
+  describe('new file with no coverage above threshold', () => {
+    beforeEach(() => {
+      // Set coverageDecreaseThreshold to 100% so we only test coverageThreshold.
+      result = diffChecker(
+        fileFullCovered,
+        newFileNotCovered,
+        undefined,
+        40,
+        100,
+        40
+      );
+    });
+
+    it('should not regress', () => {
+      // Total is now 50% but the first file didn't change so no regression
+      expect(result.regression).toBe(false);
+    });
+
+    it('should be below threshold', () => {
+      // Total is now 50% but file threshold is 40%, and new file threshold is 40, so it should be below the threshold
+      expect(result.belowThreshold).toBe(true);
+    });
+
+    it('outputs correct total percentages', () => {
+      expectToMatchObject(result.totals, {
+        belowThreshold: false,
+        decreased: false, // Threshold is 40
+        pcts: {
+          branches: 50,
+          functions: 50,
+          lines: 50,
+          statements: 50
+        }
+      });
+    });
+  });
+
+  describe('new file with half coverage below threshold', () => {
+    beforeEach(() => {
+      // Set coverageDecreaseThreshold to 100% so we only test coverageThreshold.
+      result = diffChecker(
+        fileFullCovered,
+        newFileHalfCovered,
+        undefined,
+        40,
+        100,
+        60
+      );
+    });
+
+    it('should not regress', () => {
+      // Total is now 75% and the first file didn't change so no regression
+      expect(result.regression).toBe(false);
+    });
+
+    it.only('should be below threshold', () => {
+      // Total is now 75% but file threshold is 60% so it should be belowThreshold
+      expect(result.belowThreshold).toBe(true);
+    });
+
+    it('outputs correct total percentages', () => {
+      expectToMatchObject(result.totals, {
+        belowThreshold: false, // Threshold is 60, total is 75, total is not below, but file is
+        decreased: false, 
+        pcts: {
+          branches: 75,
+          functions: 75,
+          lines: 75,
+          statements: 75
+        }
+      });
+    });
+  });
+
+  describe('new file with half coverage above threshold', () => {
+    beforeEach(() => {
+      // Set coverageDecreaseThreshold to 100% so we only test coverageThreshold.
+      result = diffChecker(
+        fileFullCovered,
+        newFileNotCovered,
+        undefined,
+        40,
+        100,
+        45
+      );
+    });
+
+    it('should not regress', () => {
+      // Total is now 50% but the first file didn't change so no regression
+      expect(result.regression).toBe(false);
+    });
+
+    it('should not be below threshold', () => {
+      // Total is now 50% but file threshold is 40%, and new file threshold is 45, so it should be above the threshold
+      expect(result.belowThreshold).toBe(false);
+    });
+
+    it('outputs correct total percentages', () => {
+      expectToMatchObject(result.totals, {
+        belowThreshold: false, // Threshold is 40, total is 50
+        decreased: false, 
         pcts: {
           branches: 50,
           functions: 50,

--- a/src/diffChecker.ts
+++ b/src/diffChecker.ts
@@ -32,7 +32,11 @@ export const diffChecker = (
   const isBelowThreshold = (x: number) => x < coverageThreshold;
   const isBelowNewFileThreshold = (x: number) => x < newFileCoverageThreshold;
 
-  const checkItemBelowThreshold = (diff: CoverageSummary, coverageToCompare: CoverageSummary, checkCriteria: Criteria[]) => {
+  const checkItemBelowThreshold = (
+    diff: CoverageSummary,
+    coverageToCompare: CoverageSummary,
+    checkCriteria: Criteria[]
+  ) => {
     const condition = diff.isNewFile
       ? isBelowNewFileThreshold
       : isBelowThreshold;
@@ -41,7 +45,7 @@ export const diffChecker = (
       checkCriteria,
       condition
     );
-  }
+  };
 
   const checkItemDecreased = (
     diff: CoverageSummary,
@@ -51,7 +55,6 @@ export const diffChecker = (
     return checkCoverageForCondition(diff, checkCriteria, coverageDecreased);
   };
 
-
   diffMap.forEach((diff, fileName) => {
     const diffPercentages = getSummaryPercentages(diff);
     if (shouldExcludeItem(diff, diffPercentages)) {
@@ -59,7 +62,11 @@ export const diffChecker = (
     }
 
     const itemDecreased = checkItemDecreased(diff, checkCriteria);
-    const itemBelowThreshold = checkItemBelowThreshold(diff, head[fileName], checkCriteria)
+    const itemBelowThreshold = checkItemBelowThreshold(
+      diff,
+      head[fileName],
+      checkCriteria
+    );
 
     // Coverage decreased on a file, regress.
     // only check file specific regressions, ignore regressions in the total, regression should still be set
@@ -81,9 +88,8 @@ export const diffChecker = (
       pcts: getSummaryPercentages(head[fileName]),
       isNewFile: diff.isNewFile,
       decreased: itemDecreased,
-      belowThreshold: itemBelowThreshold,
+      belowThreshold: itemBelowThreshold
     });
-    
   });
 
   let totals = percentageMap.get('total');
@@ -133,13 +139,14 @@ const checkCoverageForCondition = (
 
 const zeroTest = (x: number) => x === 0;
 
-const shouldExcludeItem = (diff: CoverageSummary, diffPercentages: ReturnType<typeof getSummaryPercentages>) => {
+const shouldExcludeItem = (
+  diff: CoverageSummary,
+  diffPercentages: ReturnType<typeof getSummaryPercentages>
+) => {
   if (diff.isNewFile) {
     return false;
-  }
-  else {
+  } else {
     // if every value is zero, exclude the item from the diff because nothing has changed
-    return Object.values(diffPercentages).every(zeroTest)
+    return Object.values(diffPercentages).every(zeroTest);
   }
-}
-
+};

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -61,9 +61,8 @@ describe('diff', () => {
         mockedOptions.checkCriteria,
         mockedOptions.coverageThreshold,
         mockedOptions.coverageDecreaseThreshold,
-        mockedOptions.newFileCoverageThreshold,
+        mockedOptions.newFileCoverageThreshold
       );
     });
-
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -24,7 +24,8 @@ describe('diff', () => {
         fileFullCovered,
         coverageDiff.defaultOptions.checkCriteria,
         coverageDiff.defaultOptions.coverageThreshold,
-        coverageDiff.defaultOptions.coverageDecreaseThreshold
+        coverageDiff.defaultOptions.coverageDecreaseThreshold,
+        coverageDiff.defaultOptions.newFileCoverageThreshold // will be undefined - defaults to coverageThreshold in diffChecker
       );
     });
 
@@ -48,7 +49,8 @@ describe('diff', () => {
       const mockedOptions: ConfigOptions = {
         checkCriteria: ['lines'],
         coverageThreshold: 100,
-        coverageDecreaseThreshold: 0
+        coverageDecreaseThreshold: 0,
+        newFileCoverageThreshold: 1
       };
 
       coverageDiff.diff(fileNotCovered, fileFullCovered, mockedOptions);
@@ -58,26 +60,10 @@ describe('diff', () => {
         fileFullCovered,
         mockedOptions.checkCriteria,
         mockedOptions.coverageThreshold,
-        mockedOptions.coverageDecreaseThreshold
+        mockedOptions.coverageDecreaseThreshold,
+        mockedOptions.newFileCoverageThreshold,
       );
     });
 
-    it('should call the diffChecker module with deprecated option', () => {
-      const mockedOptions: ConfigOptions = {
-        checkCriteria: ['lines'],
-        coverageThreshold: 100,
-        coverageDecreaseThreshold: 0
-      };
-
-      coverageDiff.diff(fileNotCovered, fileFullCovered, mockedOptions);
-
-      expect(diffCheckerSpy).toHaveBeenCalledWith(
-        fileNotCovered,
-        fileFullCovered,
-        mockedOptions.checkCriteria,
-        mockedOptions.coverageThreshold,
-        mockedOptions.coverageDecreaseThreshold
-      );
-    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,12 @@ export function diff(
   head: JsonSummary,
   options = defaultOptions
 ): CoverageDiffOutput {
-  const { checkCriteria, coverageThreshold, coverageDecreaseThreshold, newFileCoverageThreshold } =
-    options;
+  const {
+    checkCriteria,
+    coverageThreshold,
+    coverageDecreaseThreshold,
+    newFileCoverageThreshold
+  } = options;
 
   const { regression, files, totals, diff, belowThreshold } = diffChecker(
     base,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export function diff(
   head: JsonSummary,
   options = defaultOptions
 ): CoverageDiffOutput {
-  const { checkCriteria, coverageThreshold, coverageDecreaseThreshold } =
+  const { checkCriteria, coverageThreshold, coverageDecreaseThreshold, newFileCoverageThreshold } =
     options;
 
   const { regression, files, totals, diff, belowThreshold } = diffChecker(
@@ -25,7 +25,8 @@ export function diff(
     head,
     checkCriteria,
     coverageThreshold,
-    coverageDecreaseThreshold
+    coverageDecreaseThreshold,
+    newFileCoverageThreshold
   );
 
   const results = resultFormatter(files, totals);

--- a/src/resultFormatter.test.ts
+++ b/src/resultFormatter.test.ts
@@ -3,6 +3,7 @@ import { resultFormatter } from './resultFormatter';
 
 const filesResults: FilesResults = {
   file1: {
+    isNewFile: false,
     deltas: {
       lines: 10,
       statements: -10,
@@ -19,6 +20,41 @@ const filesResults: FilesResults = {
     belowThreshold: false
   },
   file2: {
+    isNewFile: false,
+    deltas: {
+      lines: 10,
+      statements: 10,
+      functions: 20,
+      branches: 30
+    },
+    pcts: {
+      lines: 20,
+      statements: 5,
+      functions: 2,
+      branches: 8
+    },
+    decreased: false,
+    belowThreshold: false
+  },
+  file3: {
+    isNewFile: false,
+    deltas: {
+      lines: 10,
+      statements: 10,
+      functions: 20,
+      branches: 30
+    },
+    pcts: {
+      lines: 20,
+      statements: 5,
+      functions: 2,
+      branches: 8
+    },
+    decreased: false,
+    belowThreshold: true
+  },
+  file4: {
+    isNewFile: true,
     deltas: {
       lines: 10,
       statements: 10,
@@ -37,6 +73,7 @@ const filesResults: FilesResults = {
 };
 
 const totalResults: FileResultFormat = {
+  isNewFile: false,
   deltas: {
     lines: 100,
     functions: 100,

--- a/src/resultFormatter.ts
+++ b/src/resultFormatter.ts
@@ -33,14 +33,14 @@ const formatTotal = (total: FileResultFormat): string => {
 const formatFilesResults = (files: FilesResults): string => {
   let noChange = true;
   const table: Array<(string | number)[]> = [];
-  const header = ['Ok', 'File', 'Lines', 'Branches', 'Functions', 'Statements'];
+  const header = ['Ok', 'File (✨=New File)', 'Lines', 'Branches', 'Functions', 'Statements'];
   table.push(header);
 
   Object.keys(files).forEach((file) => {
-    const { deltas, pcts, decreased } = files[file];
+    const { deltas, pcts, decreased, belowThreshold, isNewFile } = files[file];
     const row = [
-      decreased ? '🔴' : '✅',
-      file,
+      decreased || belowThreshold ? '🔴' : '✅',
+      `${isNewFile ? '✨ ' : ''}${file}`,
       `${pcts.lines}%<br>(${formatDelta(deltas.lines)})`,
       `${pcts.branches}%<br>(${formatDelta(deltas.branches)})`,
       `${pcts.functions}%<br>(${formatDelta(deltas.functions)})`,

--- a/src/resultFormatter.ts
+++ b/src/resultFormatter.ts
@@ -33,7 +33,14 @@ const formatTotal = (total: FileResultFormat): string => {
 const formatFilesResults = (files: FilesResults): string => {
   let noChange = true;
   const table: Array<(string | number)[]> = [];
-  const header = ['Ok', 'File (✨=New File)', 'Lines', 'Branches', 'Functions', 'Statements'];
+  const header = [
+    'Ok',
+    'File (✨=New File)',
+    'Lines',
+    'Branches',
+    'Functions',
+    'Statements'
+  ];
   table.push(header);
 
   Object.keys(files).forEach((file) => {

--- a/src/summaries.fixture.ts
+++ b/src/summaries.fixture.ts
@@ -2,6 +2,7 @@ import { JsonSummary } from './common';
 
 export const fileFullCovered: JsonSummary = {
   total: {
+    isNewFile: false,
     lines: {
       total: 2,
       covered: 2,
@@ -28,6 +29,7 @@ export const fileFullCovered: JsonSummary = {
     }
   },
   fileA: {
+    isNewFile: false,
     lines: {
       total: 2,
       covered: 2,
@@ -58,6 +60,7 @@ export const fileFullCovered: JsonSummary = {
 export const fileFullCoveredfileHalfCovered: JsonSummary = {
   ...fileFullCovered,
   fileB: {
+    isNewFile: false,
     lines: {
       total: 2,
       covered: 1,
@@ -84,6 +87,7 @@ export const fileFullCoveredfileHalfCovered: JsonSummary = {
     }
   },
   total: {
+    isNewFile: false,
     lines: {
       total: 4,
       covered: 3,
@@ -113,6 +117,7 @@ export const fileFullCoveredfileHalfCovered: JsonSummary = {
 
 export const fileNotCovered: JsonSummary = {
   total: {
+    isNewFile: false,
     lines: {
       total: 2,
       covered: 0,
@@ -139,6 +144,7 @@ export const fileNotCovered: JsonSummary = {
     }
   },
   fileA: {
+    isNewFile: false,
     lines: {
       total: 2,
       covered: 0,
@@ -168,6 +174,7 @@ export const fileNotCovered: JsonSummary = {
 
 export const fileHalfCovered: JsonSummary = {
   total: {
+    isNewFile: false,
     lines: {
       total: 2,
       covered: 1,
@@ -194,6 +201,7 @@ export const fileHalfCovered: JsonSummary = {
     }
   },
   fileA: {
+    isNewFile: false,
     lines: {
       total: 2,
       covered: 1,
@@ -224,6 +232,7 @@ export const fileHalfCovered: JsonSummary = {
 export const coverageNotChanged: JsonSummary = {
   ...fileFullCovered,
   fileA: {
+    isNewFile: false,
     lines: {
       total: 2,
       covered: 1,
@@ -253,6 +262,7 @@ export const coverageNotChanged: JsonSummary = {
 
 export const coverageDecreased: JsonSummary = {
   total: {
+    isNewFile: false,
     lines: {
       total: 0,
       covered: 1,
@@ -279,6 +289,7 @@ export const coverageDecreased: JsonSummary = {
     }
   },
   fileA: {
+    isNewFile: false,
     lines: {
       total: 0,
       covered: -1,
@@ -309,6 +320,7 @@ export const coverageDecreased: JsonSummary = {
 export const totalDecreased: JsonSummary = {
   ...coverageNotChanged,
   total: {
+    isNewFile: false,
     lines: {
       total: 2,
       covered: 1,
@@ -349,9 +361,80 @@ export const onlyLinesIncreased: JsonSummary = {
   }
 };
 
-export const newFile: JsonSummary = {
+export const newFile: JsonSummary ={
   ...fileFullCovered,
   fileB: {
     ...fileFullCovered.fileA
+  }
+};
+
+export const newFileNotCovered: JsonSummary = {
+  ...fileFullCovered,
+  total: {
+    isNewFile: false,
+    lines: {
+      total: 4,
+      covered: 2,
+      skipped: 0,
+      pct: 50
+    },
+    statements: {
+      total: 4,
+      covered: 2,
+      skipped: 0,
+      pct: 50
+    },
+    functions: {
+      total: 4,
+      covered: 2,
+      skipped: 0,
+      pct: 50
+    },
+    branches: {
+      total: 4,
+      covered: 2,
+      skipped: 0,
+      pct: 50
+    }
+  },
+  fileB: {
+    ...fileNotCovered.fileA,
+    isNewFile: true
+  }
+};
+
+
+export const newFileHalfCovered: JsonSummary = {
+  ...fileFullCovered,
+  total: {
+    isNewFile: false,
+    lines: {
+      total: 4,
+      covered: 3,
+      skipped: 0,
+      pct: 75
+    },
+    statements: {
+      total: 4,
+      covered: 3,
+      skipped: 0,
+      pct: 75
+    },
+    functions: {
+      total: 4,
+      covered: 3,
+      skipped: 0,
+      pct: 75
+    },
+    branches: {
+      total: 4,
+      covered: 3,
+      skipped: 0,
+      pct: 75
+    }
+  },
+  fileB: {
+    ...fileHalfCovered.fileA,
+    isNewFile: true
   }
 };

--- a/src/summaries.fixture.ts
+++ b/src/summaries.fixture.ts
@@ -361,7 +361,7 @@ export const onlyLinesIncreased: JsonSummary = {
   }
 };
 
-export const newFile: JsonSummary ={
+export const newFile: JsonSummary = {
   ...fileFullCovered,
   fileB: {
     ...fileFullCovered.fileA
@@ -402,7 +402,6 @@ export const newFileNotCovered: JsonSummary = {
     isNewFile: true
   }
 };
-
 
 export const newFileHalfCovered: JsonSummary = {
   ...fileFullCovered,


### PR DESCRIPTION
Added a configuration item for new files. This is useful when you want to enforce a higher coverage threshold on new files, but not force a high threshold on existing files. This way you can set the `coverageThreshold` low (to 0 for example) and set the `newFileCoverageThreshold` to something higher to force new files to have a higher threshold.

- Added newFileCoverageThreshold to the config input
- Added isNewFile to the summary output for each file
- Added an icon to the report for new files (`✨`), see example below
- Previously new files wouldn't be included in the report if they didn't have coverage and coverageThreshold was set to 0, now newFileCoverageThreshold can be used to force them to be

> | Ok | File (✨=New File) | Lines         | Branches      | Functions    | Statements    |
> | -- | ----------------- | ------------- | ------------- | ------------ | ------------- |
> | 🔴 | file1             | 80%<br>(+10%) | 14%<br>(-30%) | 3%<br>(+20%) | 20%<br>(-10%) |
> | ✅  | file2             | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
> | 🔴 | file3             | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
> | ✅  | ✨ file4           | 20%<br>(+10%) | 8%<br>(+30%)  | 2%<br>(+20%) | 5%<br>(+10%)  |
> 
> Total:
> 
> | Lines       | Branches    | Functions   | Statements  |
> | ----------- | ----------- | ----------- | ----------- |
> | 100%(+100%) | 100%(+100%) | 100%(+100%) | 100%(+100%) |
