### PR TITLE
Add new option: customFormatter

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -35,7 +35,7 @@ export interface ConfigOptions {
   coverageDecreaseThreshold?: number;
   /* Fail coverage check if per-file coverage is lower than this for new files only */
   newFileCoverageThreshold?: number;
-  /* Use it to generate your custom output */
+  /* Function to generate a custom output based on the diff */
   customFormatter?: (files: FilesResults, totals: FileResultFormat) => string;
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -35,6 +35,8 @@ export interface ConfigOptions {
   coverageDecreaseThreshold?: number;
   /* Fail coverage check if per-file coverage is lower than this for new files only */
   newFileCoverageThreshold?: number;
+  /* Use it to generate your custom output */
+  customFormatter?: (files: FilesResults, totals: FileResultFormat) => string;
 }
 
 export interface DiffCheckResults {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -50,7 +50,8 @@ describe('diff', () => {
         checkCriteria: ['lines'],
         coverageThreshold: 100,
         coverageDecreaseThreshold: 0,
-        newFileCoverageThreshold: 1
+        newFileCoverageThreshold: 1,
+        customFormatter: jest.fn(),
       };
 
       coverageDiff.diff(fileNotCovered, fileFullCovered, mockedOptions);
@@ -63,6 +64,10 @@ describe('diff', () => {
         mockedOptions.coverageDecreaseThreshold,
         mockedOptions.newFileCoverageThreshold
       );
+      expect(mockedOptions.customFormatter).toHaveBeenCalledWith('mockedFiles', {
+        deltas: 'mockedTotals',
+        pcts: 'mockedPcts'
+      })
     });
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -51,7 +51,7 @@ describe('diff', () => {
         coverageThreshold: 100,
         coverageDecreaseThreshold: 0,
         newFileCoverageThreshold: 1,
-        customFormatter: jest.fn(),
+        customFormatter: jest.fn()
       };
 
       coverageDiff.diff(fileNotCovered, fileFullCovered, mockedOptions);
@@ -64,10 +64,13 @@ describe('diff', () => {
         mockedOptions.coverageDecreaseThreshold,
         mockedOptions.newFileCoverageThreshold
       );
-      expect(mockedOptions.customFormatter).toHaveBeenCalledWith('mockedFiles', {
-        deltas: 'mockedTotals',
-        pcts: 'mockedPcts'
-      })
+      expect(mockedOptions.customFormatter).toHaveBeenCalledWith(
+        'mockedFiles',
+        {
+          deltas: 'mockedTotals',
+          pcts: 'mockedPcts'
+        }
+      );
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ export function diff(
     checkCriteria,
     coverageThreshold,
     coverageDecreaseThreshold,
-    newFileCoverageThreshold
+    newFileCoverageThreshold,
+    customFormatter
   } = options;
 
   const { regression, files, totals, diff, belowThreshold } = diffChecker(
@@ -33,7 +34,7 @@ export function diff(
     newFileCoverageThreshold
   );
 
-  const results = resultFormatter(files, totals);
+  const results = customFormatter?.(files, totals) || resultFormatter(files, totals);
 
   return {
     diff,

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,8 @@ export function diff(
     newFileCoverageThreshold
   );
 
-  const results = customFormatter?.(files, totals) || resultFormatter(files, totals);
+  const results =
+    customFormatter?.(files, totals) || resultFormatter(files, totals);
 
   return {
     diff,


### PR DESCRIPTION
### Add new option: customFormatter
Add a new option `customFormatter` to generate a custom `result` based on the coverage diff.

Fixes: https://github.com/flaviusone/coverage-diff/issues/36